### PR TITLE
Magento 2.3 csrf fix

### DIFF
--- a/Helper/General.php
+++ b/Helper/General.php
@@ -309,7 +309,8 @@ class General extends AbstractHelper
      */
     public function getWebhookUrl()
     {
-        return $this->urlBuilder->getUrl('mollie/checkout/webhook/');
+        $urlParams = '?isAjax=1';
+        return $this->urlBuilder->getUrl('mollie/checkout/webhook/') . $urlParams;
     }
 
     /**


### PR DESCRIPTION
Recently this file was added to Magento 2: https://github.com/magento/magento2/blob/2.3-develop/lib/internal/Magento/Framework/App/Request/CsrfValidator.php

The method `validateRequest` breaks the Mollie webhook, because Mollie makes a POST request to the webhook, without adding the "isAjax" parameter to the URL.

```
/**
     * @param HttpRequest $request
     * @param ActionInterface  $action
     *
     * @return bool
     */
    private function validateRequest(
        HttpRequest $request,
        ActionInterface $action
    ): bool {
        $valid = null;
        if ($action instanceof CsrfAwareActionInterface) {
            $valid = $action->validateForCsrf($request);
        }
        if ($valid === null) {
            $valid = !$request->isPost()
                || $request->isAjax()
                || $this->formKeyValidator->validate($request);
        }
        return $valid;
    }
```